### PR TITLE
lowercase domain

### DIFF
--- a/src/DisposableDomains.php
+++ b/src/DisposableDomains.php
@@ -5,6 +5,7 @@ namespace Propaganistas\LaravelDisposableEmail;
 use ErrorException;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Propaganistas\LaravelDisposableEmail\Traits\ParsesJson;
 
 class DisposableDomains

--- a/src/DisposableDomains.php
+++ b/src/DisposableDomains.php
@@ -110,7 +110,7 @@ class DisposableDomains
      */
     public function isDisposable($email)
     {
-        if ($domain = Arr::get(explode('@', $email, 2), 1)) {
+        if ($domain = Str::lower(Arr::get(explode('@', $email, 2), 1))) {
             return in_array($domain, $this->domains);
         }
 


### PR DESCRIPTION
Function in_array() is case-sensitive. If the example.com domain is in the blacklist, then Example.com it passes validation. RFC 1035 domain is case-insensitive. Therefore, it can be converted to lowercase before validation.