### PR TITLE
Fix unserialize() error when using Redis as cache

### DIFF
--- a/config/disposable-email.php
+++ b/config/disposable-email.php
@@ -64,7 +64,7 @@ return [
     'cache' => [
         'enabled' => true,
         'store' => 'default',
-        'key' => 'disposable_email.domains',
+        'key' => 'disposable_email_domains',
     ],
 
 ];

--- a/config/disposable-email.php
+++ b/config/disposable-email.php
@@ -64,7 +64,7 @@ return [
     'cache' => [
         'enabled' => true,
         'store' => 'default',
-        'key' => 'disposable_email_domains',
+        'key' => 'disposable_email:domains',
     ],
 
 ];


### PR DESCRIPTION
Using the key `disposable_email.domains` in Redis throw an error `unserialize(): Error at offset XYZ of XYZ bytes`, Redis cannot unserialize keys with dot notation.
Is better to replace the key with underscore so it works in most cache drivers.