### PR TITLE
Adding status artisan command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Uses the disposable domains blacklist from [disposable/disposable](https://githu
 	}
     ```
 
+7. (optional) You can see the disposable domains list status running the following artisan command:
+    
+    ```bash
+    php artisan disposable:status
+    ```
+
 ### Usage
 
 Use the `indisposable` validator to ensure a given field doesn't hold a disposable email address. You'll probably want to add it after the `email` validator to make sure a valid email is passed through:

--- a/src/Console/StatusDisposableDomainsCommand.php
+++ b/src/Console/StatusDisposableDomainsCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Propaganistas\LaravelDisposableEmail\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Config\Repository as Config;
+use Propaganistas\LaravelDisposableEmail\Contracts\Fetcher;
+use Propaganistas\LaravelDisposableEmail\DisposableDomains;
+
+class StatusDisposableDomainsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'disposable:status';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Shows the status of disposable domains';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Contracts\Config\Repository  $config
+     * @param  \Propaganistas\LaravelDisposableEmail\DisposableDomains  $disposable
+     * @return  void
+     */
+    public function handle(Config $config, DisposableDomains $disposable)
+    {
+        $this->line('Getting informations for disposable domains...');
+        
+        if (!file_exists($disposable->getStoragePath())) {
+            $this->error('Could not find disposable domains at ' . $disposable->getStoragePath());
+            return 1;
+        }
+
+        $lastUpdate = date('Y-m-d H:i:s', filemtime($disposable->getStoragePath()));
+        $linesCount = count($disposable->getDomains());
+
+        $this->info('Last updated disposable domains list at: ' . $lastUpdate);
+        $this->info('Number of disposable domains founded: ' . $linesCount);
+        return 0;
+    }
+}
+

--- a/src/Console/StatusDisposableDomainsCommand.php
+++ b/src/Console/StatusDisposableDomainsCommand.php
@@ -43,7 +43,7 @@ class StatusDisposableDomainsCommand extends Command
         $linesCount = count($disposable->getDomains());
 
         $this->info('Last updated disposable domains list at: ' . $lastUpdate);
-        $this->info('Number of disposable domains founded: ' . $linesCount);
+        $this->info('Number of disposable domains founded: ' . $linesCount . ' domains');
         return 0;
     }
 }

--- a/src/Console/UpdateDisposableDomainsCommand.php
+++ b/src/Console/UpdateDisposableDomainsCommand.php
@@ -52,10 +52,11 @@ class UpdateDisposableDomainsCommand extends Command
         if ($disposable->saveToStorage($data)) {
             $this->info('Disposable domains list updated successfully.');
             $disposable->bootstrap();
+            $this->call('disposable:status');
             return 0;
-        } else {
-            $this->error('Could not write to storage ('.$disposable->getStoragePath().')!');
-            return 1;
         }
+
+        $this->error('Could not write to storage (' . $disposable->getStoragePath() . ')!');
+        return 1;
     }
 }

--- a/src/DisposableEmailServiceProvider.php
+++ b/src/DisposableEmailServiceProvider.php
@@ -4,6 +4,7 @@ namespace Propaganistas\LaravelDisposableEmail;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Factory;
+use Propaganistas\LaravelDisposableEmail\Console\StatusDisposableDomainsCommand;
 use Propaganistas\LaravelDisposableEmail\Console\UpdateDisposableDomainsCommand;
 use Propaganistas\LaravelDisposableEmail\Validation\Indisposable;
 
@@ -25,6 +26,7 @@ class DisposableEmailServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands(UpdateDisposableDomainsCommand::class);
+            $this->commands(StatusDisposableDomainsCommand::class);
         }
 
         $this->publishes([


### PR DESCRIPTION
hello man, i suggest this PR in order to facilitate to get informations of disposable domains status.
im started with just the two most important pieces of information:

1 - date of last update
2 - number of domains in the list

when the list is downloaded
![image](https://user-images.githubusercontent.com/60560085/227723169-1b643f35-3a9a-4a1b-81d8-14926ab7568f.png)

when the list is not downloaded
![image](https://user-images.githubusercontent.com/60560085/227723331-2c50520d-5458-4f56-ac43-bf6b8f0a7367.png)


do you think we can add any more relevant information?