### PR TITLE
Laravel 11.x Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,4 +55,4 @@ jobs:
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,15 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.0, 8.1, 8.2, 8.3 ]
-        laravel: [ 8, 9, 10 ]
+        laravel: [ 8, 9, 10, 11 ]
         stability: [ prefer-lowest, prefer-stable ]
         exclude:
           - php: 8.0
             laravel: 10
+          - php: 8.0
+            laravel: 11
+          - php: 8.1
+            laravel: 11
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} (${{ matrix.stability }})
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 composer.phar
 composer.lock
 .phpunit.result.cache
+
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "mockery/mockery": "^1.4.2",
         "orchestra/testbench": "*",
-        "phpunit/phpunit": "^9.5.10|^10.5"
+        "phpunit/phpunit": "^9.5.10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "mockery/mockery": "^1.4.2",
         "orchestra/testbench": "*",
-        "phpunit/phpunit": "^9.5.10"
+        "phpunit/phpunit": "^9.5.10|^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "illuminate/cache": "^8.0|^9.0|^10.0",
-        "illuminate/config": "^8.0|^9.0|^10.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "illuminate/console": "^8.0|^9.0|^10.0",
-        "illuminate/validation": "^8.0|^9.0|^10.0"
+        "illuminate/cache": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/config": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/console": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/validation": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4.2",
         "orchestra/testbench": "*",
-        "phpunit/phpunit": "^9.5.10"
+        "phpunit/phpunit": "^9.5.10|^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        backupGlobals="false"
+        bootstrap="vendor/autoload.php"
+        colors="true"
+        processIsolation="false"
+        stopOnFailure="false"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+        cacheDirectory=".phpunit.cache"
+        backupStaticProperties="false"
+>
+  <testsuites>
+    <testsuite name="Package Test Suite">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
This pull request introduces support for PHP 8.3 and Laravel 11 in the testing matrix, along with updates to illuminate dependencies.
