### PR TITLE
Allow installation with Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
             stability: prefer-stable
         exclude:
           - laravel: 13
-          - php: 8.2
+            php: 8.2
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} (${{ matrix.stability }})
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
             php: 8.1
             stability: prefer-stable
         exclude:
-          - laravel: 10
+          - laravel: 13
           - php: 8.2
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} (${{ matrix.stability }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.2, 8.3, 8.4, 8.5 ]
-        laravel: [ 10, 11, 12 ]
+        laravel: [ 10, 11, 12, 13 ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 10
@@ -23,6 +23,9 @@ jobs:
           - laravel: 10
             php: 8.1
             stability: prefer-stable
+        exclude:
+          - laravel: 10
+          - php: 8.2
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} (${{ matrix.stability }})
 

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "illuminate/cache": "^10.0|^11.0|^12.0",
-        "illuminate/config": "^10.0|^11.0|^12.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "illuminate/console": "^10.0|^11.0|^12.0",
-        "illuminate/validation": "^10.0|^11.0|^12.0"
+        "illuminate/cache": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/config": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/validation": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4.2",


### PR DESCRIPTION
* Allow installation with Laravel 13, and add to the text matrix
* Exclude Laravel 13 from testing against PHP 8.2